### PR TITLE
Improve hints UI

### DIFF
--- a/layout/main.css
+++ b/layout/main.css
@@ -52,3 +52,35 @@ body {
 .error > input[type=text] {
   background-color: indianred;
 }
+
+.hint {
+  display: grid;
+
+  * {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  p {
+    &.locked {
+      filter: blur(8px);
+    }
+
+    &.unlocked {
+      transition: filter 1s;
+    }
+  }
+
+  button {
+    justify-self: center;
+    align-self: center;
+
+    cursor: pointer;
+    z-index: 10;
+    background-color: black;
+    color: white;
+    border: 0;
+    padding: 5px 15px;
+    border-radius: 5px;
+  }
+}

--- a/layout/main.js
+++ b/layout/main.js
@@ -1,6 +1,5 @@
 const root = document.getElementById('input')
 if (root) {
-  const hints = document.getElementById('hints')
   const unlocks = document.getElementById('unlocks')
   const guesses = document.getElementById('guesses')
   root.onsubmit = async (event) => {
@@ -37,22 +36,21 @@ if (root) {
     root.classList.remove('error')
     root.classList.remove('correct')
   }
-  hints.onclick = (event) => {
-    if (event.target.tagName !== 'LI') {
-      return
-    }
-    const hintRequested = [...event.target.parentNode.children].indexOf(event.target)
+
+  document.querySelector('.hint button').addEventListener('click', (event) => {
+    const parent = event.target.closest('.hint')
+    const hintId = parseInt(parent.dataset.index)
     const puzzle = root.elements.puzzle.value
-    if (!confirm(`Are you sure you want to request hint ${hintRequested+1}?`)) {
-      return
-    }
+
     fetch('/hint', {
       method: 'POST',
-      body: JSON.stringify({puzzle: puzzle, hintRequested: hintRequested})
+      body: JSON.stringify({puzzle: puzzle, hintRequested: hintId})
     })
         .then(res => res.json())
         .then(response => {
-          hints.children[response.hintRequested].innerText = response.hint
+          parent.querySelector('p').innerText = response.hint
+          parent.querySelector('p').className = 'unlocked'
+          event.target.remove()
         })
-  }
+  })
 }

--- a/layout/puzzle.html
+++ b/layout/puzzle.html
@@ -19,8 +19,11 @@
 <div id="info">
   <h2>Hints ({{ len .Metadata.Hints }})</h2>
   <ol id="hints">
-      {{ range $hint := .Metadata.Hints }}
-      <li>[Click to reveal]</li>
+      {{ range $index, $hint := .Metadata.Hints }}
+      <li class="hint" data-index="{{ $index }}">
+        <p class="locked">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+        <button>Reveal this hint</button>
+      </li>
       {{ end }}
   </ol>
   <h2>Unlocks</h2>


### PR DESCRIPTION
Make the thing you need to click on an actual button, overlayed on some dummy text that fades in when
the hint is revealed.

Remove confirmation dialog as it's now a lot harder to accidentally click on a hint.

[Peek 2024-12-27 14-42.webm](https://github.com/user-attachments/assets/a93c2a8f-ab4f-4294-a3ad-43383bf69b68)
